### PR TITLE
Remove added newline after result

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,7 +74,7 @@ export function activate(context: vscode.ExtensionContext) {
 			editor.edit(builder => {
 				try {
 					const result = converter(selectedText);
-					builder.replace(selection, result + '\n');
+					builder.replace(selection, result);
 				} catch (e) {
 					vscode.window.showErrorMessage(e);
 				}


### PR DESCRIPTION
Let the result expression itself add a newline if it needs it. This fixes inline conversions.